### PR TITLE
ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ auto
 tools/travis/dist
 # Various editor workspaces
 .vscode/
+# from Mac OS
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,3 @@ auto
 tools/travis/dist
 # Various editor workspaces
 .vscode/
-# Mac OS desktop adds this
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ auto
 tools/travis/dist
 # Various editor workspaces
 .vscode/
+# Mac OS desktop adds this
+.DS_Store

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -24,3 +24,6 @@
 \.synctex\.gz$
 \.fdb_latexmk$
 ^931_test(\w+)\.epub$
+
+# Mac OSX metadata
+\B\.DS_Store


### PR DESCRIPTION
The Mac OS X Finder app (the file explorer GUI) adds a .DS_Store file to every directory the user interacts with.